### PR TITLE
[UX] replace ✔️ with ✅ to indicate success

### DIFF
--- a/src/utils/generate_progress.test.ts
+++ b/src/utils/generate_progress.test.ts
@@ -97,7 +97,7 @@ describe("generate progress tests", () => {
       checksStatusLookup,
       config,
     );
-    expect(progress).toContain(":heavy_check_mark:");
+    expect(progress).toContain(":white_check_mark:");
   });
 
   test("should include correct marks", () => {
@@ -110,7 +110,7 @@ describe("generate progress tests", () => {
       checksStatusLookupWithFailure,
       config,
     );
-    expect(progress).toContain(":heavy_check_mark:");
+    expect(progress).toContain(":white_check_mark:");
     expect(progress).toContain(":x:");
   });
 
@@ -123,7 +123,7 @@ describe("generate progress tests", () => {
       checksStatusLookupWithMissing,
       config,
     );
-    expect(progress).toContain(":heavy_check_mark:");
+    expect(progress).toContain(":white_check_mark:");
     expect(progress).toContain(":hourglass:");
   });
 

--- a/src/utils/generate_progress.ts
+++ b/src/utils/generate_progress.ts
@@ -110,7 +110,7 @@ export const statusToMark = (
   if (check in checksStatusLookup) {
     /* eslint-disable security/detect-object-injection */
     if (checksStatusLookup[check] == "success") {
-      return ":heavy_check_mark:";
+      return ":white_check_mark:";
     }
     if (checksStatusLookup[check] == "failure") {
       return ":x:";


### PR DESCRIPTION
minor visual improvement to make "success" more obvious, esp. in github's dark mode. The ✔️ is not very visible in dark mode.